### PR TITLE
Sous media recipe

### DIFF
--- a/assets/scaffold/recipes/sous_admin/recipe.yml
+++ b/assets/scaffold/recipes/sous_admin/recipe.yml
@@ -1,6 +1,6 @@
 name: 'Sous Admin'
 description: 'A recipe that contains modules, themes, and configuration for the Sous administration experience.'
-type: 'Sous'
+type: 'Site'
 
 install:
   # Install core dependencies.

--- a/assets/scaffold/recipes/sous_media/LICENSE
+++ b/assets/scaffold/recipes/sous_media/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Four Kitchens
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/assets/scaffold/recipes/sous_media/README.md
+++ b/assets/scaffold/recipes/sous_media/README.md
@@ -1,0 +1,26 @@
+# Sous Media Drupal Recipe
+A recipe that contains modules and configuration for the Sous media experience.
+
+This module configures three media types:
+- file
+- image
+- video
+
+## Configuring Drupal for Recipes
+
+See https://www.drupal.org/files/issues/2023-10-01/Configuring%20Drupal%20to%20Apply%20Recipes.md
+
+## Installing this Recipe
+
+`composer require fourkitchens/sous_media`
+
+## Applying this Recipe
+
+If you used the Sous Project as your starterkit:
+- `lando install-recipe sous_media` 
+
+Manually applying the recipe to your own project:
+From your webroot run: 
+- `php core/scripts/drupal recipe recipes/sous_media`
+- `drush cr`
+- `composer unpack fourkitchens/sous_media`

--- a/assets/scaffold/recipes/sous_media/composer.json
+++ b/assets/scaffold/recipes/sous_media/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "fourkitchens/sous_media",
+    "description": "A recipe that contains modules and configuration for the Sous media experience.",
+    "keywords": ["recipe", "Drupal recipes", "drupal recipe"],
+    "type": "drupal-recipe",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Laura Johnson",
+            "role": "Maintainer"
+        }
+    ],
+    "minimum-stability": "dev",
+    "require": {
+        "drupal/media_library_edit": "^3.0",
+        "drupal/focal_point": "^2.0"
+    }
+}

--- a/assets/scaffold/recipes/sous_media/config/core.entity_form_display.media.file.default.yml
+++ b/assets/scaffold/recipes/sous_media/config/core.entity_form_display.media.file.default.yml
@@ -1,0 +1,106 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.file.field_description
+    - field.field.media.file.field_media_file
+    - field.field.media.file.field_tags
+    - media.type.file
+  module:
+    - field_group
+    - file
+    - text
+third_party_settings:
+  field_group:
+    group_tabs:
+      children:
+        - group_file_content
+        - group_file_details
+      label: Tabs
+      region: content
+      parent_name: ''
+      weight: 0
+      format_type: tabs
+      format_settings:
+        classes: ''
+        id: ''
+        direction: horizontal
+    group_file_content:
+      children:
+        - name
+        - field_media_file
+      label: 'File Content'
+      region: content
+      parent_name: group_tabs
+      weight: 9
+      format_type: tab
+      format_settings:
+        classes: ''
+        id: ''
+        formatter: open
+        description: ''
+        required_fields: true
+    group_file_details:
+      children:
+        - field_description
+        - field_tags
+      label: 'File Details'
+      region: content
+      parent_name: group_tabs
+      weight: 10
+      format_type: tab
+      format_settings:
+        classes: ''
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+id: media.file.default
+targetEntityType: media
+bundle: file
+mode: default
+content:
+  field_description:
+    type: text_textarea
+    weight: 3
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_media_file:
+    type: file_generic
+    weight: 2
+    region: content
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+  field_tags:
+    type: entity_reference_autocomplete_tags
+    weight: 4
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 4
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden:
+  created: true
+  path: true
+  uid: true

--- a/assets/scaffold/recipes/sous_media/config/core.entity_form_display.media.image.default.yml
+++ b/assets/scaffold/recipes/sous_media/config/core.entity_form_display.media.image.default.yml
@@ -1,0 +1,129 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.image.field_caption
+    - field.field.media.image.field_copyright
+    - field.field.media.image.field_description
+    - field.field.media.image.field_media_image
+    - field.field.media.image.field_tags
+    - image.style.thumbnail
+    - media.type.image
+  module:
+    - field_group
+    - image
+    - text
+third_party_settings:
+  field_group:
+    group_image_details:
+      children:
+        - field_caption
+        - field_description
+        - field_copyright
+        - field_tags
+      label: 'Image Details'
+      region: content
+      parent_name: group_tabs
+      weight: 10
+      format_type: tab
+      format_settings:
+        classes: ''
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+        open: false
+    group_tabs:
+      children:
+        - group_image_content
+        - group_image_details
+      label: Tabs
+      region: content
+      parent_name: ''
+      weight: 0
+      format_type: tabs
+      format_settings:
+        classes: ''
+        id: ''
+        direction: horizontal
+    group_image_content:
+      children:
+        - name
+        - field_media_image
+      label: 'Image Content'
+      region: content
+      parent_name: group_tabs
+      weight: 9
+      format_type: tab
+      format_settings:
+        classes: ''
+        id: ''
+        formatter: open
+        description: ''
+        required_fields: true
+id: media.image.default
+targetEntityType: media
+bundle: image
+mode: default
+content:
+  field_caption:
+    type: string_textarea
+    weight: 8
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_copyright:
+    type: string_textfield
+    weight: 10
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_description:
+    type: text_textarea
+    weight: 9
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_media_image:
+    type: image_image
+    weight: 3
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  field_tags:
+    type: entity_reference_autocomplete
+    weight: 11
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden:
+  created: true
+  path: true
+  uid: true

--- a/assets/scaffold/recipes/sous_media/config/core.entity_form_display.media.video.default.yml
+++ b/assets/scaffold/recipes/sous_media/config/core.entity_form_display.media.video.default.yml
@@ -1,0 +1,138 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.video.field_caption
+    - field.field.media.video.field_copyright
+    - field.field.media.video.field_description
+    - field.field.media.video.field_media_oembed_video
+    - field.field.media.video.field_tags
+    - field.field.media.video.field_transcript
+    - media.type.video
+  module:
+    - field_group
+    - link
+    - media
+    - text
+third_party_settings:
+  field_group:
+    group_tabs:
+      children:
+        - group_video_content
+        - group_video_details
+      label: Tabs
+      region: content
+      parent_name: ''
+      weight: 0
+      format_type: tabs
+      format_settings:
+        classes: ''
+        id: ''
+        direction: horizontal
+    group_video_content:
+      children:
+        - name
+        - field_media_oembed_video
+      label: 'Video Content'
+      region: content
+      parent_name: group_tabs
+      weight: 12
+      format_type: tab
+      format_settings:
+        classes: ''
+        id: ''
+        formatter: open
+        description: ''
+        required_fields: true
+    group_video_details:
+      children:
+        - field_caption
+        - field_description
+        - field_copyright
+        - field_transcript
+        - field_tags
+      label: 'Video Details'
+      region: content
+      parent_name: group_tabs
+      weight: 13
+      format_type: tab
+      format_settings:
+        classes: ''
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+id: media.video.default
+targetEntityType: media
+bundle: video
+mode: default
+content:
+  field_caption:
+    type: string_textarea
+    weight: 4
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_copyright:
+    type: string_textfield
+    weight: 6
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_description:
+    type: text_textarea
+    weight: 5
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_media_oembed_video:
+    type: oembed_textfield
+    weight: 12
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_tags:
+    type: entity_reference_autocomplete
+    weight: 8
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_transcript:
+    type: link_default
+    weight: 7
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 11
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 1
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden:
+  created: true
+  path: true
+  uid: true

--- a/assets/scaffold/recipes/sous_media/config/core.entity_view_display.media.file.default.yml
+++ b/assets/scaffold/recipes/sous_media/config/core.entity_view_display.media.file.default.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.file.field_description
+    - field.field.media.file.field_media_file
+    - field.field.media.file.field_tags
+    - media.type.file
+  module:
+    - file
+id: media.file.default
+targetEntityType: media
+bundle: file
+mode: default
+content:
+  field_media_file:
+    type: file_default
+    label: visually_hidden
+    settings:
+      use_description_as_link_text: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_description: true
+  field_tags: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/assets/scaffold/recipes/sous_media/config/core.entity_view_display.media.file.media_library.yml
+++ b/assets/scaffold/recipes/sous_media/config/core.entity_view_display.media.file.media_library.yml
@@ -1,0 +1,35 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.file.field_description
+    - field.field.media.file.field_media_file
+    - field.field.media.file.field_tags
+    - image.style.medium
+    - media.type.file
+  module:
+    - image
+id: media.file.media_library
+targetEntityType: media
+bundle: file
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: medium
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_description: true
+  field_media_file: true
+  field_tags: true
+  name: true
+  uid: true

--- a/assets/scaffold/recipes/sous_media/config/core.entity_view_display.media.file.preview.yml
+++ b/assets/scaffold/recipes/sous_media/config/core.entity_view_display.media.file.preview.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.preview
+    - field.field.media.file.field_description
+    - field.field.media.file.field_media_file
+    - field.field.media.file.field_tags
+    - image.style.medium
+    - media.type.file
+  module:
+    - image
+id: media.file.preview
+targetEntityType: media
+bundle: file
+mode: preview
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: medium
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_description: true
+  field_media_file: true
+  field_tags: true
+  name: true
+  uid: true

--- a/assets/scaffold/recipes/sous_media/config/core.entity_view_display.media.image.default.yml
+++ b/assets/scaffold/recipes/sous_media/config/core.entity_view_display.media.image.default.yml
@@ -1,0 +1,48 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.image.field_caption
+    - field.field.media.image.field_copyright
+    - field.field.media.image.field_description
+    - field.field.media.image.field_media_image
+    - field.field.media.image.field_tags
+    - media.type.image
+  module:
+    - image
+id: media.image.default
+targetEntityType: media
+bundle: image
+mode: default
+content:
+  field_caption:
+    type: basic_string
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_copyright:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_media_image:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_description: true
+  field_tags: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/assets/scaffold/recipes/sous_media/config/core.entity_view_display.media.image.media_library.yml
+++ b/assets/scaffold/recipes/sous_media/config/core.entity_view_display.media.image.media_library.yml
@@ -1,0 +1,39 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.image.field_caption
+    - field.field.media.image.field_copyright
+    - field.field.media.image.field_description
+    - field.field.media.image.field_media_image
+    - field.field.media.image.field_tags
+    - image.style.medium
+    - media.type.image
+  module:
+    - image
+id: media.image.media_library
+targetEntityType: media
+bundle: image
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: medium
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_caption: true
+  field_copyright: true
+  field_description: true
+  field_media_image: true
+  field_tags: true
+  name: true
+  uid: true

--- a/assets/scaffold/recipes/sous_media/config/core.entity_view_display.media.image.preview.yml
+++ b/assets/scaffold/recipes/sous_media/config/core.entity_view_display.media.image.preview.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.preview
+    - field.field.media.image.field_caption
+    - field.field.media.image.field_copyright
+    - field.field.media.image.field_description
+    - field.field.media.image.field_media_image
+    - field.field.media.image.field_tags
+    - image.style.medium
+    - media.type.image
+  module:
+    - image
+id: media.image.preview
+targetEntityType: media
+bundle: image
+mode: preview
+content:
+  field_media_image:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: medium
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_caption: true
+  field_copyright: true
+  field_description: true
+  field_tags: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/assets/scaffold/recipes/sous_media/config/core.entity_view_display.media.video.default.yml
+++ b/assets/scaffold/recipes/sous_media/config/core.entity_view_display.media.video.default.yml
@@ -1,0 +1,64 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.video.field_caption
+    - field.field.media.video.field_copyright
+    - field.field.media.video.field_description
+    - field.field.media.video.field_media_oembed_video
+    - field.field.media.video.field_tags
+    - field.field.media.video.field_transcript
+    - media.type.video
+  module:
+    - link
+    - media
+id: media.video.default
+targetEntityType: media
+bundle: video
+mode: default
+content:
+  field_caption:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_copyright:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_media_oembed_video:
+    type: oembed
+    label: hidden
+    settings:
+      max_width: 0
+      max_height: 0
+      loading:
+        attribute: eager
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_transcript:
+    type: link
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 2
+    region: content
+hidden:
+  created: true
+  field_description: true
+  field_tags: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/assets/scaffold/recipes/sous_media/config/core.entity_view_display.media.video.media_library.yml
+++ b/assets/scaffold/recipes/sous_media/config/core.entity_view_display.media.video.media_library.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.video.field_caption
+    - field.field.media.video.field_copyright
+    - field.field.media.video.field_description
+    - field.field.media.video.field_media_oembed_video
+    - field.field.media.video.field_tags
+    - field.field.media.video.field_transcript
+    - image.style.medium
+    - media.type.video
+  module:
+    - image
+id: media.video.media_library
+targetEntityType: media
+bundle: video
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: medium
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_caption: true
+  field_copyright: true
+  field_description: true
+  field_media_oembed_video: true
+  field_tags: true
+  field_transcript: true
+  name: true
+  uid: true

--- a/assets/scaffold/recipes/sous_media/config/core.entity_view_display.media.video.preview.yml
+++ b/assets/scaffold/recipes/sous_media/config/core.entity_view_display.media.video.preview.yml
@@ -1,0 +1,39 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.preview
+    - field.field.media.video.field_caption
+    - field.field.media.video.field_copyright
+    - field.field.media.video.field_description
+    - field.field.media.video.field_media_oembed_video
+    - field.field.media.video.field_tags
+    - field.field.media.video.field_transcript
+    - image.style.medium
+    - media.type.video
+  module:
+    - image
+id: media.video.preview
+targetEntityType: media
+bundle: video
+mode: preview
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: medium
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_caption: true
+  field_copyright: true
+  field_description: true
+  field_media_oembed_video: true
+  field_tags: true
+  field_transcript: true
+  name: true
+  uid: true

--- a/assets/scaffold/recipes/sous_media/config/core.entity_view_mode.file.token.yml
+++ b/assets/scaffold/recipes/sous_media/config/core.entity_view_mode.file.token.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+id: file.token
+label: Token
+description: ''
+targetEntityType: file
+cache: true

--- a/assets/scaffold/recipes/sous_media/config/core.entity_view_mode.media.full.yml
+++ b/assets/scaffold/recipes/sous_media/config/core.entity_view_mode.media.full.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: false
+dependencies:
+  module:
+    - media
+id: media.full
+label: 'Full content'
+description: ''
+targetEntityType: media
+cache: true

--- a/assets/scaffold/recipes/sous_media/config/core.entity_view_mode.media.media_library.yml
+++ b/assets/scaffold/recipes/sous_media/config/core.entity_view_mode.media.media_library.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+  enforced:
+    module:
+      - media_library
+id: media.media_library
+label: 'Media library'
+description: ''
+targetEntityType: media
+cache: true

--- a/assets/scaffold/recipes/sous_media/config/core.entity_view_mode.media.preview.yml
+++ b/assets/scaffold/recipes/sous_media/config/core.entity_view_mode.media.preview.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.preview
+label: Preview
+description: ''
+targetEntityType: media
+cache: true

--- a/assets/scaffold/recipes/sous_media/config/core.entity_view_mode.media.token.yml
+++ b/assets/scaffold/recipes/sous_media/config/core.entity_view_mode.media.token.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.token
+label: Token
+description: ''
+targetEntityType: media
+cache: true

--- a/assets/scaffold/recipes/sous_media/config/field.field.media.file.field_description.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.field.media.file.field_description.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_description
+    - media.type.file
+  module:
+    - text
+id: media.file.field_description
+field_name: field_description
+entity_type: media
+bundle: file
+label: Description
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats: {  }
+field_type: text_long

--- a/assets/scaffold/recipes/sous_media/config/field.field.media.file.field_media_file.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.field.media.file.field_media_file.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_file
+    - media.type.file
+  module:
+    - file
+id: media.file.field_media_file
+field_name: field_media_file
+entity_type: media
+bundle: file
+label: File
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'txt doc docx pdf'
+  max_filesize: ''
+  description_field: false
+field_type: file

--- a/assets/scaffold/recipes/sous_media/config/field.field.media.file.field_tags.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.field.media.file.field_tags.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_tags
+    - media.type.file
+    - taxonomy.vocabulary.media_tags
+id: media.file.field_tags
+field_name: field_tags
+entity_type: media
+bundle: file
+label: Tags
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      media_tags: media_tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: media_tags
+field_type: entity_reference

--- a/assets/scaffold/recipes/sous_media/config/field.field.media.image.field_caption.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.field.media.image.field_caption.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_caption
+    - media.type.image
+id: media.image.field_caption
+field_name: field_caption
+entity_type: media
+bundle: image
+label: Caption
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/assets/scaffold/recipes/sous_media/config/field.field.media.image.field_copyright.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.field.media.image.field_copyright.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_copyright
+    - media.type.image
+id: media.image.field_copyright
+field_name: field_copyright
+entity_type: media
+bundle: image
+label: Copyright
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/assets/scaffold/recipes/sous_media/config/field.field.media.image.field_description.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.field.media.image.field_description.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_description
+    - media.type.image
+  module:
+    - text
+id: media.image.field_description
+field_name: field_description
+entity_type: media
+bundle: image
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats: {  }
+field_type: text_long

--- a/assets/scaffold/recipes/sous_media/config/field.field.media.image.field_media_image.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.field.media.image.field_media_image.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_image
+    - media.type.image
+  module:
+    - image
+id: media.image.field_media_image
+field_name: field_media_image
+entity_type: media
+bundle: image
+label: Image
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/assets/scaffold/recipes/sous_media/config/field.field.media.image.field_tags.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.field.media.image.field_tags.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_tags
+    - media.type.image
+    - taxonomy.vocabulary.media_tags
+id: media.image.field_tags
+field_name: field_tags
+entity_type: media
+bundle: image
+label: Tags
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      media_tags: media_tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: media_tags
+field_type: entity_reference

--- a/assets/scaffold/recipes/sous_media/config/field.field.media.video.field_caption.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.field.media.video.field_caption.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_caption
+    - media.type.video
+id: media.video.field_caption
+field_name: field_caption
+entity_type: media
+bundle: video
+label: Caption
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/assets/scaffold/recipes/sous_media/config/field.field.media.video.field_copyright.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.field.media.video.field_copyright.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_copyright
+    - media.type.video
+id: media.video.field_copyright
+field_name: field_copyright
+entity_type: media
+bundle: video
+label: Copyright
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/assets/scaffold/recipes/sous_media/config/field.field.media.video.field_description.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.field.media.video.field_description.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_description
+    - media.type.video
+  module:
+    - text
+id: media.video.field_description
+field_name: field_description
+entity_type: media
+bundle: video
+label: Description
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats: {  }
+field_type: text_long

--- a/assets/scaffold/recipes/sous_media/config/field.field.media.video.field_media_oembed_video.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.field.media.video.field_media_oembed_video.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_oembed_video
+    - media.type.video
+id: media.video.field_media_oembed_video
+field_name: field_media_oembed_video
+entity_type: media
+bundle: video
+label: 'Remote video URL'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/assets/scaffold/recipes/sous_media/config/field.field.media.video.field_tags.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.field.media.video.field_tags.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_tags
+    - media.type.video
+    - taxonomy.vocabulary.media_tags
+id: media.video.field_tags
+field_name: field_tags
+entity_type: media
+bundle: video
+label: Tags
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      media_tags: media_tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: media_tags
+field_type: entity_reference

--- a/assets/scaffold/recipes/sous_media/config/field.field.media.video.field_transcript.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.field.media.video.field_transcript.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_transcript
+    - media.type.video
+  module:
+    - link
+id: media.video.field_transcript
+field_name: field_transcript
+entity_type: media
+bundle: video
+label: Transcript
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 1
+  link_type: 17
+field_type: link

--- a/assets/scaffold/recipes/sous_media/config/field.storage.media.field_caption.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.storage.media.field_caption.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_caption
+field_name: field_caption
+entity_type: media
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/assets/scaffold/recipes/sous_media/config/field.storage.media.field_copyright.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.storage.media.field_copyright.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_copyright
+field_name: field_copyright
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/assets/scaffold/recipes/sous_media/config/field.storage.media.field_description.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.storage.media.field_description.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - text
+id: media.field_description
+field_name: field_description
+entity_type: media
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/assets/scaffold/recipes/sous_media/config/field.storage.media.field_media_file.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.storage.media.field_media_file.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - media
+id: media.field_media_file
+field_name: field_media_file
+entity_type: media
+type: file
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/assets/scaffold/recipes/sous_media/config/field.storage.media.field_media_image.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.storage.media.field_media_image.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - media
+id: media.field_media_image
+field_name: field_media_image
+entity_type: media
+type: image
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/assets/scaffold/recipes/sous_media/config/field.storage.media.field_media_oembed_video.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.storage.media.field_media_oembed_video.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_media_oembed_video
+field_name: field_media_oembed_video
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/assets/scaffold/recipes/sous_media/config/field.storage.media.field_tags.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.storage.media.field_tags.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - taxonomy
+id: media.field_tags
+field_name: field_tags
+entity_type: media
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/assets/scaffold/recipes/sous_media/config/field.storage.media.field_transcript.yml
+++ b/assets/scaffold/recipes/sous_media/config/field.storage.media.field_transcript.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - media
+id: media.field_transcript
+field_name: field_transcript
+entity_type: media
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/assets/scaffold/recipes/sous_media/config/image.style.large.yml
+++ b/assets/scaffold/recipes/sous_media/config/image.style.large.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: J2n0RpFzS0-bgSyxjs6rSdgxB1rb-bTAgqywNx_964M
+name: large
+label: 'Large (480×480)'
+effects:
+  ddd73aa7-4bd6-4c85-b600-bdf2b1628d1d:
+    uuid: ddd73aa7-4bd6-4c85-b600-bdf2b1628d1d
+    id: image_scale
+    weight: 0
+    data:
+      width: 480
+      height: 480
+      upscale: false

--- a/assets/scaffold/recipes/sous_media/config/image.style.media_library.yml
+++ b/assets/scaffold/recipes/sous_media/config/image.style.media_library.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - media_library
+name: media_library
+label: 'Media Library thumbnail (220×220)'
+effects:
+  75b076a8-1234-4b42-85db-bf377c4d8d5f:
+    uuid: 75b076a8-1234-4b42-85db-bf377c4d8d5f
+    id: image_scale
+    weight: 0
+    data:
+      width: 220
+      height: 220
+      upscale: false

--- a/assets/scaffold/recipes/sous_media/config/image.style.medium.yml
+++ b/assets/scaffold/recipes/sous_media/config/image.style.medium.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: Y9NmnZHQq20ASSyTNA6JnwtWrJJiSajOehGDtmUFdM0
+name: medium
+label: 'Medium (220×220)'
+effects:
+  bddf0d06-42f9-4c75-a700-a33cafa25ea0:
+    uuid: bddf0d06-42f9-4c75-a700-a33cafa25ea0
+    id: image_scale
+    weight: 0
+    data:
+      width: 220
+      height: 220
+      upscale: false

--- a/assets/scaffold/recipes/sous_media/config/image.style.thumbnail.yml
+++ b/assets/scaffold/recipes/sous_media/config/image.style.thumbnail.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: cCiWdBHgLwj5omG35lsKc4LkW4MBdmcctkVop4ol5x0
+name: thumbnail
+label: 'Thumbnail (100×100)'
+effects:
+  1cfec298-8620-4749-b100-ccb6c4500779:
+    uuid: 1cfec298-8620-4749-b100-ccb6c4500779
+    id: image_scale
+    weight: 0
+    data:
+      width: 100
+      height: 100
+      upscale: false

--- a/assets/scaffold/recipes/sous_media/config/image.style.wide.yml
+++ b/assets/scaffold/recipes/sous_media/config/image.style.wide.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: LswCVLg8z4Zk1u6pV1Dpj1qUj5YY2CQ7_ojx7bJQ8qk
+name: wide
+label: 'Wide (1090)'
+effects:
+  09959c15-59ce-4f6d-90df-e2d7cf32bce5:
+    uuid: 09959c15-59ce-4f6d-90df-e2d7cf32bce5
+    id: image_scale
+    weight: 1
+    data:
+      width: 1090
+      height: null
+      upscale: false

--- a/assets/scaffold/recipes/sous_media/config/media.settings.yml
+++ b/assets/scaffold/recipes/sous_media/config/media.settings.yml
@@ -1,0 +1,6 @@
+_core:
+  default_config_hash: PlWtVQXY5oKYZqCMPXh6SPamXagn5BoZqgAI8EY9WsY
+icon_base_uri: 'public://media-icons/generic'
+iframe_domain: ''
+oembed_providers_url: 'https://oembed.com/providers.json'
+standalone_url: false

--- a/assets/scaffold/recipes/sous_media/config/media.type.file.yml
+++ b/assets/scaffold/recipes/sous_media/config/media.type.file.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies: {  }
+id: file
+label: File
+description: ''
+source: file
+queue_thumbnail_downloads: false
+new_revision: true
+source_configuration:
+  source_field: field_media_file
+field_map:
+  name: name
+  mimetype: field_media_file
+  filesize: field_media_file

--- a/assets/scaffold/recipes/sous_media/config/media.type.image.yml
+++ b/assets/scaffold/recipes/sous_media/config/media.type.image.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies: {  }
+id: image
+label: Image
+description: ''
+source: image
+queue_thumbnail_downloads: false
+new_revision: true
+source_configuration:
+  source_field: field_media_image
+field_map:
+  name: name
+  mimetype: field_media_image
+  filesize: field_media_image

--- a/assets/scaffold/recipes/sous_media/config/media.type.video.yml
+++ b/assets/scaffold/recipes/sous_media/config/media.type.video.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies: {  }
+id: video
+label: Video
+description: ''
+source: 'oembed:video'
+queue_thumbnail_downloads: false
+new_revision: true
+source_configuration:
+  source_field: field_media_oembed_video
+  thumbnails_directory: 'public://oembed_thumbnails'
+  providers:
+    - YouTube
+    - Vimeo
+field_map:
+  type: field_media_oembed_video
+  title: name
+  url: field_media_oembed_video

--- a/assets/scaffold/recipes/sous_media/config/taxonomy.vocabulary.media_tags.yml
+++ b/assets/scaffold/recipes/sous_media/config/taxonomy.vocabulary.media_tags.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Media Tags'
+vid: media_tags
+description: ''
+weight: 0

--- a/assets/scaffold/recipes/sous_media/recipe.yml
+++ b/assets/scaffold/recipes/sous_media/recipe.yml
@@ -1,0 +1,23 @@
+name: 'Sous Media'
+description: 'A recipe that contains modules and configuration for the Sous media experience.'
+type: 'Site'
+
+install:
+  # Core modules
+  - file
+  - image
+  - media
+  - media_library
+  - taxonomy
+  - views
+  # Contrib modules
+  - focal_point
+  - media_library_edit
+config:
+  import:
+    # Core.
+    image: '*'
+    media: '*'
+    media_library: '*'
+    # Contrib.
+    focal_point: '*'

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,10 @@
         {
             "type": "path",
             "url": "assets/scaffold/recipes/sous_admin"
+        },
+        {
+            "type": "path",
+            "url": "assets/scaffold/recipes/sous_media"
         }
     ],
     "require": {
@@ -32,6 +36,7 @@
         "drush/drush": "^12.1",
         "ewcomposer/unpack": "dev-master",
         "fourkitchens/sous_admin": "*",
+        "fourkitchens/sous_media": "*",
         "oomphinc/composer-installers-extender": "^2.0",
         "webflo/drupal-finder": "^1.2",
         "zaporylie/composer-drupal-optimizations": "^1.0"

--- a/web/recipes/sous_media/config/taxonomy.vocabulary.media_tags.yml
+++ b/web/recipes/sous_media/config/taxonomy.vocabulary.media_tags.yml
@@ -1,0 +1,8 @@
+uuid: a68a32a0-30af-42b3-9e45-bf0c2f70520e
+langcode: en
+status: true
+dependencies: {  }
+name: 'Media Tags'
+vid: media_tags
+description: ''
+weight: 0


### PR DESCRIPTION
### Description
Installs media library and creates three media types with the same fields, form and view display, and image styles that we had in the original Sous distro.

- file
- image
- video (remote YouTube and Vimeo included)

### Included the following contrib modules:

1. focal_point (also included in original distro)
2. media_library_edit (a tiny module that adds an edit button to the media library so that it is possible to edit media in the content edit dialogue)

### Testing steps:

1. Run through the install process included in the README. You should see this recipe applied after sous_base and sous_admin.
2. Use the provided link to log in. Verify the media types and image styles are present.