### PR TITLE
feat: sous-25 create default content types recipe

### DIFF
--- a/assets/scaffold/recipes/sous_content_types/LICENSE
+++ b/assets/scaffold/recipes/sous_content_types/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Four Kitchens
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/assets/scaffold/recipes/sous_content_types/README.md
+++ b/assets/scaffold/recipes/sous_content_types/README.md
@@ -1,0 +1,21 @@
+# Sous Content Types Drupal Recipe
+A recipe that contains modules and configuration for Sous default content types.
+
+## Configuring Drupal for Recipes
+
+See https://www.drupal.org/files/issues/2023-10-01/Configuring%20Drupal%20to%20Apply%20Recipes.md
+
+## Installing this Recipe
+
+`composer require sous-starter/sous_content_types`
+
+## Applying this Recipe
+
+If you used the Sous Project as your starterkit:
+- `lando install-recipe sous_content_types` 
+
+Manually applying the recipe to your own project:
+From your webroot run: 
+- `php core/scripts/drupal recipe recipes/sous_content_types`
+- `drush cr`
+- `composer unpack fourkitchens/cookbook:sous_content_types`

--- a/assets/scaffold/recipes/sous_content_types/config/core.base_field_override.node.page.promote.yml
+++ b/assets/scaffold/recipes/sous_content_types/config/core.base_field_override.node.page.promote.yml
@@ -1,0 +1,22 @@
+uuid: 01dc8723-1fa9-454f-9955-a558ba44fa7b
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+id: node.page.promote
+field_name: promote
+entity_type: node
+bundle: page
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/assets/scaffold/recipes/sous_content_types/config/core.entity_form_display.node.page.default.yml
+++ b/assets/scaffold/recipes/sous_content_types/config/core.entity_form_display.node.page.default.yml
@@ -1,0 +1,76 @@
+uuid: 83bde531-5616-449f-b74c-640ba3ebb990
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+  module:
+    - publication_date
+    - text
+id: node.page.default
+targetEntityType: node
+bundle: page
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 121
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 15
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 120
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 16
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/assets/scaffold/recipes/sous_content_types/config/core.entity_view_display.node.page.default.yml
+++ b/assets/scaffold/recipes/sous_content_types/config/core.entity_view_display.node.page.default.yml
@@ -1,0 +1,28 @@
+uuid: 958de184-61bf-4456-b646-7ba105394c39
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+  module:
+    - text
+    - user
+id: node.page.default
+targetEntityType: node
+bundle: page
+mode: default
+content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 101
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  published_at: true

--- a/assets/scaffold/recipes/sous_content_types/config/core.entity_view_display.node.page.teaser.yml
+++ b/assets/scaffold/recipes/sous_content_types/config/core.entity_view_display.node.page.teaser.yml
@@ -1,0 +1,30 @@
+uuid: 396e02e3-e90c-4e74-863a-504fec94d209
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.page
+  module:
+    - text
+    - user
+id: node.page.teaser
+targetEntityType: node
+bundle: page
+mode: teaser
+content:
+  body:
+    type: text_summary_or_trimmed
+    label: hidden
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    weight: 101
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  published_at: true

--- a/assets/scaffold/recipes/sous_content_types/config/node.type.page.yml
+++ b/assets/scaffold/recipes/sous_content_types/config/node.type.page.yml
@@ -1,0 +1,11 @@
+uuid: c862a9a8-4b38-409e-b337-219931da46ea
+langcode: en
+status: true
+dependencies: {  }
+name: Page
+type: page
+description: 'A basic page content type.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/assets/scaffold/recipes/sous_content_types/recipe.yml
+++ b/assets/scaffold/recipes/sous_content_types/recipe.yml
@@ -1,0 +1,11 @@
+name: 'Sous Content Types'
+description: 'A recipe that contains modules and configuration for Sous default content types.'
+type: 'Sous'
+
+install:
+  # Install core dependencies.
+  - node
+  - publication_date
+  - text
+  - user
+


### PR DESCRIPTION
### Description
Installs modules related to node and creates a basic page content type with no fields.

Note that I think it's best not to add any fields because we'll be using a components field for text with a separate paragraphs content recipe.

### Testing steps:

1. Run through the install process included in the README. You should see this recipe applied after sous_base and sous_admin.
2. Use the provided link to log in. Verify the page content type is present.