### PR TITLE
Suggestions for sous_layout_builder

### DIFF
--- a/assets/scaffold/recipes/sous_layout_builder/config/field.field.block_content.text.field_text.yml
+++ b/assets/scaffold/recipes/sous_layout_builder/config/field.field.block_content.text.field_text.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - block_content.type.text
     - field.storage.block_content.field_text
+    - filter.format.basic_html
   module:
     - text
 id: block_content.text.field_text
@@ -17,5 +18,6 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  allowed_formats: {  }
+  allowed_formats:
+    - basic_html
 field_type: text_long

--- a/assets/scaffold/recipes/sous_layout_builder/config/field.field.block_content.text_with_media.field_text.yml
+++ b/assets/scaffold/recipes/sous_layout_builder/config/field.field.block_content.text_with_media.field_text.yml
@@ -4,7 +4,7 @@ dependencies:
   config:
     - block_content.type.text_with_media
     - field.storage.block_content.field_text
-    - filter.format.plain_text
+    - filter.format.basic_html
   module:
     - text
 id: block_content.text_with_media.field_text
@@ -19,5 +19,5 @@ default_value: {  }
 default_value_callback: ''
 settings:
   allowed_formats:
-    - plain_text
+    - basic_html
 field_type: text_long

--- a/assets/scaffold/recipes/sous_layout_builder/config/gin_lb.settings.yml
+++ b/assets/scaffold/recipes/sous_layout_builder/config/gin_lb.settings.yml
@@ -1,5 +1,0 @@
-toastify_loading: custom
-enable_preview_regions: false
-hide_discard_button: true
-hide_revert_button: true
-save_behavior: default

--- a/assets/scaffold/recipes/sous_layout_builder/recipe.yml
+++ b/assets/scaffold/recipes/sous_layout_builder/recipe.yml
@@ -5,10 +5,12 @@ recipes:
   - sous_content_types
 install:
   # Install core dependencies.
+  - block_content
   - gin_lb
   - layout_builder
   - layout_builder_browser
   - layout_discovery
+  - options
 config:
   actions:
     core.entity_view_display.node.page.default:
@@ -43,3 +45,7 @@ config:
             - field.field.node.page.layout_builder__layout
         hidden:
           layout_builder__layout: true
+    gin_lb.settings:
+      simple_config_update:
+        toastify_loading: custom
+        save_behavior: default


### PR DESCRIPTION
### Suggestions:

1. Add non-plain filter formats to the text fields (possible now with the formats recipe that is included with sous_content_types)
2. The recipe complained that it was missing dependencies and I added the block_content and options modules as dependencies of the recipe to fix that
3. Rather than include 3rd party config (the gin_lb.settings.yml in this case) it's preferable to use config actions to set our preferences, see the recipe.yml suggestion

**Question - maybe an issue**

I don't see the option to edit the layout on the page content type. Shouldn't we see that option? Not sure what is missing here, I checked the settings and I don't see anything obvious but I don't know LB very well...

<img width="1401" alt="sous-layout-builder" src="https://github.com/fourkitchens/sous-drupal-recipe/assets/1652730/b7cea98d-c7af-4c6d-931e-2c521be0dc14">



